### PR TITLE
Fix Cyrillic characters in transcription files

### DIFF
--- a/1_transcription/bundle_3
+++ b/1_transcription/bundle_3
@@ -294,8 +294,8 @@ File 2)	DSKC:EDLIN.A86[500,500]	created: 1007 01-JULY-1981
 2)	22380	END:	DS	2
 **************
    CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
-   СССССССССССС      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
-   СССССССССССС      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
+   CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
+   CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD      SSS                  KKK         KKK
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD      SSS                  KKK         KKK
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD      SSS                  KKK         KKK
@@ -312,8 +312,8 @@ CCC                  HHH         HHH      KKK         KKK      DDD         DDD  
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD                  SSS      KKK         KKK
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD                  SSS      KKK         KKK
    CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
-   СССССССССССС      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
-   СССССССССССС      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
+   CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
+   CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
 
 
 
@@ -347,8 +347,8 @@ AAA         AAA         888888888            666666666
 File: DSKC:CHKDSK.A86<055>[500,500] Created: 15-Jul-81 12:19:22 Printed: 28-Jul-81 14:41:18
 QUEUE Switches:  /FILE:ASCII /COPIES:1 /SPACING:1 /LIMIT:119 /FORMS:NORMAL
    CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
-   СССССССССССС      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
-   СССССССССССС      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
+   CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
+   CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD      SSS                  KKK         KKK
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD      SSS                  KKK         KKK
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD      SSS                  KKK         KKK
@@ -365,8 +365,8 @@ CCC                  HHH         HHH      KKK         KKK      DDD         DDD  
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD                  SSS      KKK         KKK
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD                  SSS      KKK         KKK
    CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
-   СССССССССССС      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
-   СССССССССССС      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
+   CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
+   CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
 
 
 

--- a/1_transcription/bundle_4
+++ b/1_transcription/bundle_4
@@ -3710,8 +3710,8 @@ QUEUE Switches:  /FILE:ASCII /COPIES:1 /SPACING:1 /LIMIT:565 /FORMS:NORMAL
 36040	MEMSTRT:
 36050	ADJFAC:	EQU	DIRBUF-MEMSTRT
    CCCCCCCCCCCC         OOOOOOOOO         MMM         MMM         AAAAAAAAA         NNN	        NNN      DDDDDDDDDDDD   
-   СССССССССССС         OOOOOOOOO         MMM         MMM         AAAAAAAAA         NNN         NNN      DDDDDDDDDDDD   
-   СССССССССССС         OOOOOOOOO         MMM         MMM         AAAAAAAAA         NNN         NNN      DDDDDDDDDDDD   
+   CCCCCCCCCCCC         OOOOOOOOO         MMM         MMM         AAAAAAAAA         NNN         NNN      DDDDDDDDDDDD   
+   CCCCCCCCCCCC         OOOOOOOOO         MMM         MMM         AAAAAAAAA         NNN         NNN      DDDDDDDDDDDD   
 CCC                  OOO         OOO      MMMMMM   MMMMMM      AAA         AAA      NNN         NNN      DDD         DDD
 CCC                  OOO         OOO      MMMMMM   MMMMMM      AAA         AAA      NNN         NNN      DDD         DDD
 CCC                  OOO         OOO      MMMMMM   MMMMMM      AAA         AAA      NNN         NNN      DDD         DDD
@@ -3728,8 +3728,8 @@ CCC                  OOO         OOO      MMM         MMM      AAA         AAA  
 CCC                  OOO         OOO      MMM         MMM      AAA         AAA      NNN         NNN      DDD         DDD
 CCC                  OOO         OOO      MMM         MMM      AAA         AAA      NNN         NNN      DDD         DDD
    CCCCCCCCCCCC         OOOOOOOOO         MMM         MMM      AAA         AAA      NNN         NNN      DDDDDDDDDDDD   
-   СССССССССССС         OOOOOOOOO         MMM         MMM      AAA         AAA      NNN         NNN      DDDDDDDDDDDD   
-   СССССССССССС         OOOOOOOOO         MMM         MMM      AAA         AAA      NNN         NNN      DDDDDDDDDDDD   
+   CCCCCCCCCCCC         OOOOOOOOO         MMM         MMM      AAA         AAA      NNN         NNN      DDDDDDDDDDDD   
+   CCCCCCCCCCCC         OOOOOOOOO         MMM         MMM      AAA         AAA      NNN         NNN      DDDDDDDDDDDD   
 
 
 

--- a/1_transcription/bundle_7
+++ b/1_transcription/bundle_7
@@ -1,6 +1,6 @@
    CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
-   СССССССССССС      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
-   СССССССССССС      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
+   CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
+   CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD            SSSSSSSSSSSS      KKK         KKK
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD      SSS                  KKK         KKK
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD      SSS                  KKK         KKK
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD      SSS                  KKK         KKK
@@ -17,8 +17,8 @@ CCC                  HHH         HHH      KKK         KKK      DDD         DDD  
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD                  SSS      KKK         KKK
 CCC                  HHH         HHH      KKK         KKK      DDD         DDD                  SSS      KKK         KKK
    CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
-   СССССССССССС      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
-   СССССССССССС      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
+   CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
+   CCCCCCCCCCCC      HHH         HHH      KKK         KKK      DDDDDDDDDDDD         SSSSSSSSSSSS         KKK         KKK
 
 
 


### PR DESCRIPTION
## Summary
- The ASCII art banners for CHKDSK (bundles 3, 7) and COMMAND (bundle 4) in `1_transcription/` incorrectly used Cyrillic 'С' (U+0421) instead of ASCII 'C'
- This affected 192 characters across 3 files: `bundle_3` (96 chars), `bundle_4` (48 chars), `bundle_7` (48 chars)
- All Cyrillic characters have been replaced with their identical-looking ASCII equivalents

## Details
The transcription files contain ASCII art page headers spelling out program names like "CHKDSK" and "COMMAND". During transcription, the letter 'C' was entered as the Cyrillic homoglyph 'С' (which looks identical but is a different Unicode codepoint). This caused the files to be detected as UTF-8 text instead of pure ASCII.

**Files changed:**
- `1_transcription/bundle_3` — lines 297, 298, 315, 316, 350, 351, 368, 369 (CHKDSK banner)
- `1_transcription/bundle_4` — lines 3713, 3714, 3731, 3732 (COMMAND banner)
- `1_transcription/bundle_7` — lines 2, 3, 20, 21 (CHKDSK banner)

## Test plan
- [x] Verified no non-ASCII characters remain in the affected files (`grep -P '[^\x00-\x7F]'` returns empty)
- [x] Verified files are now detected as pure ASCII text by `file` command
- [x] Only the Cyrillic 'С' characters were changed; no other content was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)