### PR TITLE
Add text normalization for assembly source files in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,8 @@
 LICENSE text=auto
 *.md text=auto
 *.txt text=auto
+*.asm text=auto
+*.a86 text=auto
+*.lst text=auto
+*.prn text=auto
+*.dif text=auto


### PR DESCRIPTION
## Summary
- Adds `text=auto` normalization for assembly source files (`.asm`, `.a86`), listing files (`.lst`, `.prn`), and diff files (`.dif`) in `.gitattributes`
- Previously these files were treated as binary due to `* -text`, preventing proper CRLF/LF conversion across platforms

## Problem
The current `.gitattributes`:
```
* -text
LICENSE text=auto
*.md text=auto
*.txt text=auto
```

The `* -text` rule disables line ending normalization for all files. While `.md` and `.txt` files are explicitly opted in, all assembly source files in `2_printed_files/` and `3_source_code/` are treated as binary. This causes issues:
- Git stores raw CRLF bytes without normalization
- `file` command reports some `.asm` files as "binary" due to embedded Ctrl-Z (EOF) characters combined with CRLF
- Cross-platform collaboration may introduce inconsistent line endings

## Fix
Added explicit `text=auto` for source-related file extensions:
```
*.asm text=auto
*.a86 text=auto
*.lst text=auto
*.prn text=auto
*.dif text=auto
```

This allows Git to automatically detect and normalize line endings for these text files while keeping the transcription bundle files as-is.

## Test plan
- [x] Verified `.gitattributes` syntax is correct
- [x] The `* -text` catch-all is preserved for any unlisted file types
- [x] Existing rules for LICENSE, *.md, *.txt are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)