### PR TITLE
Fix trailing period included in archive.org URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ compilable source code extracted from the printed files above
 
 If you just want to browse the source code or compile/assemble it, choose
 [`3_source_code`](./3_source_code/). The original scans, in PDF and PNG
-formats, are available at https://archive.org/details/paterson_listings.
+formats, are available at <https://archive.org/details/paterson_listings>.
 
 Further details about these listings, including technical writeups, can be
 found at:


### PR DESCRIPTION
## Summary
- The bare URL on line 26 of README.md (`https://archive.org/details/paterson_listings.`) had a trailing period that many Markdown renderers include as part of the clickable URL, resulting in a 404
- Wrapped the URL in angle brackets (`<...>`) to explicitly delimit it from the sentence period

## Before
```markdown
formats, are available at https://archive.org/details/paterson_listings.
```

## After
```markdown
formats, are available at <https://archive.org/details/paterson_listings>.
```

## Test plan
- [x] Verified the URL `https://archive.org/details/paterson_listings` resolves correctly (without the period)
- [x] Verified angle bracket syntax is valid Markdown for autolinks
- [x] Only the single URL line was modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)